### PR TITLE
Handle missing user lookup by redirecting to login

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 // @barrel ignore
 import { MyRoutes, Sidebar, Device, Light, Dark, AuthContextProvider, Menuambur, useUsuariosStore, Login, SpinnerLoader } from "./index";
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { createContext, JSX, useEffect, useState } from "react";
 import { ThemeProvider } from "styled-components";
 import { styled } from "styled-components";
@@ -14,24 +14,32 @@ type ThemeContextType = typeof Dark | null;
 
 export const ThemeContext = createContext<ThemeContextType>(null);
 function App(): JSX.Element {
-  const { setUsuario, ObtenerUsuarioActual } = useUsuariosStore();
+  const { setUsuario, clearUsuario, ObtenerUsuarioActual } = useUsuariosStore();
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const { pathname } = useLocation();
+  const navigate = useNavigate();
 
   const { data: usuario, isLoading, error } = useQuery({
     queryKey: ["mostrar usuarios"],
     queryFn: ObtenerUsuarioActual,
-  });  
+    enabled: pathname !== "/login",
+  });
 
   useEffect(() => {
     if (usuario) {
       setUsuario(usuario);
     }
   }, [usuario]);
-  
+
+  useEffect(() => {
+    if (error && pathname !== "/login") {
+      clearUsuario();
+      navigate("/login");
+    }
+  }, [clearUsuario, error, navigate, pathname]);
+
 
   if (pathname !== "/login" && isLoading) return <SpinnerLoader />;
-  if (error) return <h1>Error: {error.message}</h1>;
 
   const theme = usuario?.tema === "0" ? "light" : "dark";
 

--- a/src/store/UsuariosStore.tsx
+++ b/src/store/UsuariosStore.tsx
@@ -18,7 +18,10 @@ export const useUsuariosStore = create<UsuariosStore>((set) => ({
     localStorage.setItem("usuario", JSON.stringify(u));
     set({ usuario: u, idusuario: u.id });
   },
-  clearUsuario: () => set({ usuario: null, idusuario: 0 }),
+  clearUsuario: () => {
+    localStorage.removeItem("usuario");
+    set({ usuario: null, idusuario: 0 });
+  },
 
   editartemamonedauser: async (p) => {
     await editarTemaMonedaUser(p);


### PR DESCRIPTION
## Summary
- clear stored usuario data when clearing the user store
- redirect to the login page when fetching the current user fails and skip fetching on the login route

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921e2e45808832089dd76d9bd5ea12b)