### PR TITLE
Handle missing user lookup by redirecting to login

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ function App(): JSX.Element {
   const { pathname } = useLocation();
   const navigate = useNavigate();
 
-  const { data: usuario, isLoading, error } = useQuery({
+  const { data: usuario, isLoading, error, fetchStatus } = useQuery({
     queryKey: ["mostrar usuarios"],
     queryFn: ObtenerUsuarioActual,
     enabled: pathname !== "/login",
@@ -32,11 +32,11 @@ function App(): JSX.Element {
   }, [usuario]);
 
   useEffect(() => {
-    if (error && pathname !== "/login") {
+    if (error && fetchStatus !== "fetching" && pathname !== "/login") {
       clearUsuario();
       navigate("/login");
     }
-  }, [clearUsuario, error, navigate, pathname]);
+  }, [clearUsuario, error, fetchStatus, navigate, pathname]);
 
 
   if (pathname !== "/login" && isLoading) return <SpinnerLoader />;


### PR DESCRIPTION
## Summary
- guard the login redirect effect while the user query is refetching to avoid looping on stale errors

## Testing
- CI=1 npm run build -- --logLevel warn

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692222c1bfb48320bd05288116d5db36)