### PR TITLE
Use account-specific query key for cuentas

### DIFF
--- a/src/pages/Cuentas.tsx
+++ b/src/pages/Cuentas.tsx
@@ -14,7 +14,7 @@ export function Cuentas() {
   const { setIsLoading } = useLoading();
 
   const { isLoading, error } = useQuery<Cuenta[], Error>({
-    queryKey: ["mostrar categorias", selectTipoCuenta],
+    queryKey: ["mostrar cuentas", usuario?.id, selectTipoCuenta.tipo],
     queryFn: () =>
       mostrarCuentas({
         idusuario: usuario?.id,

--- a/src/pages/Cuentas.tsx
+++ b/src/pages/Cuentas.tsx
@@ -14,7 +14,7 @@ export function Cuentas() {
   const { setIsLoading } = useLoading();
 
   const { isLoading, error } = useQuery<Cuenta[], Error>({
-    queryKey: ["mostrar cuentas", usuario?.id, selectTipoCuenta.tipo],
+    queryKey: ["mostrar cuentas", selectTipoCuenta, usuario?.id],
     queryFn: () =>
       mostrarCuentas({
         idusuario: usuario?.id,


### PR DESCRIPTION
## Summary
- use an accounts-specific query key for the cuentas page including user id and selected type

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692231c96c20832095a7a953c0b39dae)