### PR TITLE
Fix importación de movimientos desde Excel

### DIFF
--- a/src/components/templates/ImportarMovimientosTemplate.tsx
+++ b/src/components/templates/ImportarMovimientosTemplate.tsx
@@ -2,6 +2,7 @@ import { ChangeEvent, JSX, useMemo, useRef, useState } from 'react';
 import { AlertTriangle, ArrowRightLeft, CheckCircle2, Download, FileSpreadsheet, Upload, Wrench } from 'lucide-react';
 import { Header } from '../organismos/Header';
 import { supabase } from '../../supabase/supabase.config';
+import type { Database } from '../../types/supabase';
 import { showErrorMessage, showSuccessMessage } from '../../utils/messages';
 import { downloadJson } from '../../utils/export/downloadUtils';
 import {
@@ -13,6 +14,7 @@ import {
   downloadMovimientosImportTemplate,
   groupCategoryIssues,
   ParsedMovimientoRow,
+  normalizeTipo,
   parseMovimientosWorkbook,
   validateImportRows,
 } from '../../utils/import/movimientosExcelImport';
@@ -45,6 +47,7 @@ type Step = 1 | 2 | 3;
 
 const PREVIEW_LIMIT = 20;
 const INSERT_CHUNK_SIZE = 200;
+type MovimientoImportPayload = Database['public']['Tables']['movimientos']['Insert'];
 
 export const ImportarMovimientosTemplate = ({ userId, categorias, cuentas }: ImportarMovimientosTemplateProps): JSX.Element => {
   const [step, setStep] = useState<Step>(1);
@@ -67,8 +70,9 @@ export const ImportarMovimientosTemplate = ({ userId, categorias, cuentas }: Imp
     const result: Record<'i' | 'g', CategoriaImportRef[]> = { i: [], g: [] };
     categorias.forEach((item) => {
       if (item.idusuario !== userId) return;
-      if (item.tipo === 'i' || item.tipo === 'ingreso') result.i.push(item);
-      if (item.tipo === 'g' || item.tipo === 'gasto') result.g.push(item);
+      const tipo = normalizeTipo(item.tipo).value;
+      if (tipo === 'i') result.i.push(item);
+      if (tipo === 'g') result.g.push(item);
     });
     return result;
   }, [categorias, userId]);
@@ -113,7 +117,12 @@ export const ImportarMovimientosTemplate = ({ userId, categorias, cuentas }: Imp
       return;
     }
 
-    const payload = validation.rows.map((row) => (
+    if (validation.rows.length === 0) {
+      showErrorMessage('No hay filas válidas para importar.');
+      return;
+    }
+
+    const payload: MovimientoImportPayload[] = validation.rows.map((row) => (
       row.tipo === 't'
         ? {
             fecha: row.fecha,
@@ -147,18 +156,20 @@ export const ImportarMovimientosTemplate = ({ userId, categorias, cuentas }: Imp
     setIsImporting(true);
 
     for (const chunk of chunks) {
-      const { error } = await supabase.from('movimientos').insert(chunk as never);
+      const { error } = await supabase.from('movimientos').insert(chunk);
       if (error) {
-        setIsImporting(false);
         setProgress({ done: inserted, total: payload.length, failed: chunk.length });
         showErrorMessage(`Error al importar: ${error.message}`);
-        return;
+        break;
       }
       inserted += chunk.length;
       setProgress({ done: inserted, total: payload.length, failed: 0 });
     }
 
     setIsImporting(false);
+
+    if (inserted !== payload.length) return;
+
     showSuccessMessage(`Importación completada. Se insertaron ${inserted} movimientos.`);
     setRows([]);
     setSelectedFixes({});

--- a/src/test/movimientosExcelImport.test.ts
+++ b/src/test/movimientosExcelImport.test.ts
@@ -1,3 +1,4 @@
+import ExcelJS from 'exceljs';
 import { describe, expect, it } from 'vitest';
 import {
   applyCategoryCorrection,
@@ -5,6 +6,7 @@ import {
   groupCategoryIssues,
   normalizeTipo,
   ParsedMovimientoRow,
+  parseMovimientosWorkbook,
   validateImportRows,
 } from '../utils/import/movimientosExcelImport';
 
@@ -13,6 +15,22 @@ describe('normalizeTipo', () => {
     expect(normalizeTipo('ingreso')).toMatchObject({ kind: 'valid', value: 'i' });
     expect(normalizeTipo('g')).toMatchObject({ kind: 'valid', value: 'g' });
     expect(normalizeTipo('transferencia')).toMatchObject({ kind: 'valid', value: 't' });
+  });
+});
+
+describe('parseMovimientosWorkbook', () => {
+  it('parses localized number strings from Excel rows', async () => {
+    const workbook = new ExcelJS.Workbook();
+    const worksheet = workbook.addWorksheet('Movimientos');
+    worksheet.addRow(['fecha', 'descripcion', 'tipo', 'valor', 'idcategoria', 'idcuenta', 'idcuenta_origen', 'idcuenta_destino']);
+    worksheet.addRow(['2026-01-10', 'Compra con separadores', 'gasto', '$ 1.234,56', 1, 100, '', '']);
+    worksheet.addRow(['2026-01-11', 'Ingreso con formato US', 'ingreso', '2,345.67', 2, 100, '', '']);
+
+    const buffer = await workbook.xlsx.writeBuffer();
+    const rows = await parseMovimientosWorkbook(buffer as ArrayBuffer);
+
+    expect(rows[0].valor).toBe(1234.56);
+    expect(rows[1].valor).toBe(2345.67);
   });
 });
 

--- a/src/utils/import/movimientosExcelImport.ts
+++ b/src/utils/import/movimientosExcelImport.ts
@@ -96,11 +96,35 @@ const asDateYyyyMmDd = (value: unknown): string => {
   return text;
 };
 
+const normalizeNumberText = (value: string): string => {
+  const compactValue = value.trim().replace(/\s/g, '').replace(/[^\d,.-]/g, '');
+  const lastComma = compactValue.lastIndexOf(',');
+  const lastDot = compactValue.lastIndexOf('.');
+
+  if (lastComma >= 0 && lastDot >= 0) {
+    const decimalSeparator = lastComma > lastDot ? ',' : '.';
+    const thousandsSeparator = decimalSeparator === ',' ? '.' : ',';
+    return compactValue
+      .replace(new RegExp(`\\${thousandsSeparator}`, 'g'), '')
+      .replace(decimalSeparator, '.');
+  }
+
+  if (lastComma >= 0) {
+    return compactValue.replace(/\./g, '').replace(',', '.');
+  }
+
+  const dotMatches = compactValue.match(/\./g);
+  if (dotMatches && dotMatches.length > 1) {
+    return compactValue.replace(/\./g, '');
+  }
+
+  return compactValue;
+};
+
 const asNumber = (value: unknown): number | null => {
   if (value == null || value === '') return null;
   if (typeof value === 'number') return Number.isFinite(value) ? value : null;
-  const sanitized = String(value).replace(/\s/g, '').replace(',', '.');
-  const parsed = Number(sanitized);
+  const parsed = Number(normalizeNumberText(String(value)));
   return Number.isFinite(parsed) ? parsed : null;
 };
 
@@ -402,12 +426,12 @@ export const chunkRows = <T,>(rows: T[], size: number): T[][] => {
 export interface TemplateCategory {
   id: number;
   tipo: string | null;
-  descripcion: string | null;
+  descripcion?: string | null;
 }
 
 export interface TemplateCuenta {
   id: number;
-  descripcion: string | null;
+  descripcion?: string | null;
 }
 
 export const downloadMovimientosImportTemplate = async (categories: TemplateCategory[], cuentas: TemplateCuenta[]): Promise<void> => {
@@ -443,7 +467,7 @@ export const downloadMovimientosImportTemplate = async (categories: TemplateCate
   categoriasSheet.addRow(['tipo', 'idcategoria', 'descripcion']);
   categories.forEach((item) => {
     const tipo = normalizeTipo(item.tipo).value;
-    if (!tipo) return;
+    if (tipo !== 'i' && tipo !== 'g') return;
     categoriasSheet.addRow([
       tipo === 'i' ? 'ingreso' : 'gasto',
       item.id,


### PR DESCRIPTION
### Motivation
- Mejorar robustez del flujo de importación desde Excel para soportar formatos numéricos localizados y símbolos de moneda. 
- Evitar inserciones incorrectas o vacías y usar los tipos de Supabase para tipar el payload de importación.
- Normalizar el manejo de tipos de categoría entre plantilla/validación/UI y mejorar la UX ante fallos parciales de lote.

### Description
- Añade `normalizeNumberText` y mejora `asNumber` para parsear importes con separadores locales y símbolos (p.e. `$ 1.234,56` y `2,345.67`). (``src/utils/import/movimientosExcelImport.ts``).
- Ajusta las interfaces de plantilla para que `descripcion` sea opcional en `TemplateCategory` y `TemplateCuenta`, y excluye tipos no aplicables al generar la hoja `Categorias` (``downloadMovimientosImportTemplate``).
- En la UI de importación (`ImportarMovimientosTemplate`) importa el tipo `Database` y define `MovimientoImportPayload = Database['public']['Tables']['movimientos']['Insert']` para tipar el payload de inserción, evita intentar importar cuando no hay filas válidas, elimina el cast a `never` y cambia la lógica para romper el envío de chunks al primer error (manteniendo el progreso consistente) y sólo mostrar éxito si se insertó todo el payload (``src/components/templates/ImportarMovimientosTemplate.tsx``).
- Normaliza el tipo de categoría al construir `categoriesByType` usando `normalizeTipo` para evitar inconsistencias entre valores como `i|ingreso` y `g|gasto` (``src/components/templates/ImportarMovimientosTemplate.tsx``).
- Agrega un test que valida el parseo de importes localizados desde un workbook Excel real (``src/test/movimientosExcelImport.test.ts``).

### Testing
- Ejecutado `npm test -- src/test/movimientosExcelImport.test.ts` y el nuevo test pasó: ✓ (6 tests in that file).
- Ejecutado `npm test` y la suite completa pasó: ✓ (4 archivos de test, 31 tests en total, todos pasados).
- Ejecutado `npm run build` y la aplicación se compiló correctamente con warnings preexistentes de Vite (chunks grandes y uso de `eval` en una dependencia) — build OK.
- `npm run lint` sigue fallando por problemas de configuración/alcance de `ts-standard` y `parserOptions.project` que están fuera de este cambio: ⚠️ (preexistente).
- `npx tsc --noEmit -p tsconfig.app.json` presenta errores de tipado preexistentes en el repo que no fueron introducidos por este ajuste: ⚠️ (preexistente).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa301580b48320af91eb88149cc12a)