### PR TITLE
Mejora UX en Informes y simplificación de rutas lazy

### DIFF
--- a/src/components/templates/InformesTemplate.tsx
+++ b/src/components/templates/InformesTemplate.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import { CalendarioLineal, Header, Tabs, Btndesplegable, ListaMenuDesplegable, DataDesplegableMovimientos, useOperaciones, Tipo, useUsuariosStore, v, DataMovimientos, MovimientosMesAnioAll, useMovimientosStore, SpinnerLoader, useCuentaStore, Cuenta, DataRptMovimientosAñoMes, Selector, ListaGenerica } from "../../index";
-import { JSX, useEffect, useState } from "react";
+import { JSX, useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { downloadJson } from "../../utils/export/downloadUtils";
 import { exportToExcel } from "../../utils/export/excelExport";
@@ -16,7 +16,7 @@ export const InformesTemplate = (): JSX.Element => {
     selectTipoMovimiento: tipo,
     date,
   } = useOperaciones();
-  const { idusuario } = useUsuariosStore();
+  const { idusuario, usuario } = useUsuariosStore();
   const { datamovimientos, mostrarMovimientos } = useMovimientosStore();
   const { mostrarCuentas } = useCuentaStore();
   const [stateTipo, setStateTipo] = useState<boolean>(false);
@@ -103,8 +103,32 @@ export const InformesTemplate = (): JSX.Element => {
     };
   };
 
+  const reportData = useMemo(() => getDataForExport(), [datamovimientos, tipo.tipo]);
+
+  const reportSummary = useMemo(() => {
+    const ingresos = reportData.i || [];
+    const gastos = reportData.g || [];
+    const transferencias = reportData.t || [];
+    const sum = (items: DataMovimientos['i']): number =>
+      items.reduce((total, item) => total + Number(item.valor || 0), 0);
+
+    return {
+      totalIngresos: sum(ingresos),
+      totalGastos: sum(gastos),
+      totalTransferencias: sum(transferencias),
+      totalRegistros: ingresos.length + gastos.length + transferencias.length,
+    };
+  }, [reportData]);
+
+  const hasReportRows = reportSummary.totalRegistros > 0;
+
+  const formatCurrency = (valor: number): string =>
+    `${usuario?.moneda || '$'} ${new Intl.NumberFormat('es-ES', {
+      maximumFractionDigits: 0,
+    }).format(valor)}`;
+
   const getRowsForJsonExport = (): MovimientosMesAnioAll => {
-    const data = getDataForExport();
+    const data = reportData;
     const rows: MovimientosMesAnioAll = [];
 
     (['i', 'g', 't'] as const).forEach((tipoMovimiento) => {
@@ -172,7 +196,7 @@ export const InformesTemplate = (): JSX.Element => {
   const handleExportExcel = async (): Promise<void> => {
     setExporting('excel');
     try {
-      await exportToExcel(getDataForExport(), `informe-${getPeriodo()}.xlsx`);
+      await exportToExcel(reportData, `informe-${getPeriodo()}.xlsx`);
     } catch (error) {
       logger.error('Error al exportar Excel', { error });
       showErrorMessage('No se pudo exportar el informe en formato Excel.');
@@ -187,7 +211,7 @@ export const InformesTemplate = (): JSX.Element => {
       exportToPdf({
         titulo: `Informe ${tipo.text}`,
         periodo: getPeriodo(),
-        data: getDataForExport(),
+        data: reportData,
         filename: `informe-${getPeriodo()}.pdf`,
       });
     } catch (error) {
@@ -198,7 +222,7 @@ export const InformesTemplate = (): JSX.Element => {
     }
   };
 
-  const exportDisabled = exporting !== null || isLoadingMovimientos || isLoadingCuentas || !idusuario;
+  const exportDisabled = exporting !== null || isLoadingMovimientos || isLoadingCuentas || !idusuario || !hasReportRows;
 
   if (showMinimumLoading || isLoadingMovimientos || isLoadingCuentas || !idusuario) {
     return <SpinnerLoader />;
@@ -310,8 +334,33 @@ export const InformesTemplate = (): JSX.Element => {
           </button>
         </ExportButtons>
       </section>
+      <SummaryGrid aria-label="Resumen del informe">
+        <SummaryCard $tone="income">
+          <span>Ingresos</span>
+          <strong>{formatCurrency(reportSummary.totalIngresos)}</strong>
+        </SummaryCard>
+        <SummaryCard $tone="expense">
+          <span>Gastos</span>
+          <strong>{formatCurrency(reportSummary.totalGastos)}</strong>
+        </SummaryCard>
+        <SummaryCard $tone="transfer">
+          <span>Transferencias</span>
+          <strong>{formatCurrency(reportSummary.totalTransferencias)}</strong>
+        </SummaryCard>
+        <SummaryCard $tone="count">
+          <span>Registros</span>
+          <strong>{reportSummary.totalRegistros}</strong>
+        </SummaryCard>
+      </SummaryGrid>
       <section className="main">
-        <Tabs dataOverride={getChartDataForCuenta()} />
+        {hasReportRows ? (
+          <Tabs dataOverride={getChartDataForCuenta()} />
+        ) : (
+          <EmptyState>
+            <strong>No hay movimientos para este filtro</strong>
+            <span>Cambia el mes, el tipo o la cuenta para ver datos y habilitar la exportación.</span>
+          </EmptyState>
+        )}
       </section>
     </Container>
   );
@@ -326,6 +375,7 @@ const Container = styled.div`
   grid-template:
     "header" 100px
     "area1" auto
+    "summary" auto
     "main" auto;
 
   .header {
@@ -494,5 +544,68 @@ const CuentaFilter = styled.div<{ $active?: boolean }>`
   .cuenta-list > div {
     width: 100%;
     min-width: 260px;
+  }
+`;
+
+const SummaryGrid = styled.section`
+  grid-area: summary;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 12px;
+  margin: 0 0 18px;
+`;
+
+const SummaryCard = styled.article<{ $tone: 'income' | 'expense' | 'transfer' | 'count' }>`
+  border-radius: 20px;
+  padding: 16px;
+  background: ${({ theme }) => theme.bg};
+  border: 1px solid ${({ $tone }) => {
+    const colors = {
+      income: '#22c55e',
+      expense: '#ef4444',
+      transfer: '#9955ff',
+      count: '#0ea5e9',
+    };
+    return colors[$tone];
+  }}33;
+  box-shadow: 0 16px 30px rgba(0, 0, 0, 0.08);
+
+  span {
+    display: block;
+    color: ${({ theme }) => theme.colorSubtitle};
+    font-size: 0.78rem;
+    font-weight: 800;
+    margin-bottom: 8px;
+  }
+
+  strong {
+    display: block;
+    color: ${({ theme }) => theme.text};
+    font-size: clamp(1.15rem, 2vw, 1.55rem);
+    line-height: 1.15;
+  }
+`;
+
+const EmptyState = styled.div`
+  width: min(100%, 760px);
+  margin: 32px auto;
+  padding: 34px 24px;
+  border: 1px dashed #9955ff66;
+  border-radius: 26px;
+  background: ${({ theme }) => theme.bg}cc;
+  color: ${({ theme }) => theme.text};
+  text-align: center;
+  box-shadow: 0 18px 34px rgba(0, 0, 0, 0.08);
+
+  strong {
+    display: block;
+    font-size: clamp(1.2rem, 2vw, 1.6rem);
+    margin-bottom: 8px;
+  }
+
+  span {
+    color: ${({ theme }) => theme.colorSubtitle};
+    display: block;
+    line-height: 1.5;
   }
 `;

--- a/src/components/templates/InformesTemplate.tsx
+++ b/src/components/templates/InformesTemplate.tsx
@@ -592,7 +592,7 @@ const EmptyState = styled.div`
   padding: 34px 24px;
   border: 1px dashed #9955ff66;
   border-radius: 26px;
-  background: ${({ theme }) => theme.bg}cc;
+  background: color-mix(in srgb, ${({ theme }) => theme.bg} 80%, transparent);
   color: ${({ theme }) => theme.text};
   text-align: center;
   box-shadow: 0 18px 34px rgba(0, 0, 0, 0.08);

--- a/src/routers/routes.tsx
+++ b/src/routers/routes.tsx
@@ -1,33 +1,41 @@
-import { lazy, Suspense } from "react";
+import { lazy, Suspense, type ComponentType } from "react";
 import { Routes, Route } from "react-router-dom";
 import AuthCallback from "../pages/AuthCallback";
 import { ProtectedRoute } from "../hooks/ProtectedRoute";
 import { useUserAuth } from "../context/AuthContent";
 import { SpinnerLoader } from "../components/moleculas/SpinnerLoader";
 
-const Login = lazy(async () => await import("../pages/Login").then((module) => ({ default: module.Login })));
-const Home = lazy(async () => await import("../pages/Home").then((module) => ({ default: module.Home })));
-const Configuracion = lazy(
-  async () => await import("../pages/Configuracion").then((module) => ({ default: module.Configuracion }))
-);
-const Categorias = lazy(
-  async () => await import("../pages/Categorias").then((module) => ({ default: module.Categorias }))
-);
-const Movimientos = lazy(
-  async () => await import("../pages/Movimientos").then((module) => ({ default: module.Movimientos }))
-);
-const ImportarMovimientos = lazy(
-  async () => await import("../pages/ImportarMovimientos").then((module) => ({ default: module.ImportarMovimientos }))
-);
-const Informes = lazy(
-  async () => await import("../pages/Informes").then((module) => ({ default: module.Informes }))
-);
-const Vincular = lazy(async () => await import("../pages/Vincular").then((module) => ({ default: module.Vincular })));
-const Conexiones = lazy(
-  async () => await import("../pages/Conexiones").then((module) => ({ default: module.Conexiones }))
-);
-const Dashboard = lazy(async () => await import("../pages/Dashboard").then((module) => ({ default: module.Dashboard })));
-const Cuentas = lazy(async () => await import("../pages/Cuentas").then((module) => ({ default: module.Cuentas })));
+const lazyPage = <TModule extends Record<TExport, ComponentType>, TExport extends keyof TModule>(
+  importer: () => Promise<TModule>,
+  exportName: TExport
+) => lazy(async () => await importer().then((module) => ({ default: module[exportName] })));
+
+const Login = lazyPage(() => import("../pages/Login"), "Login");
+const Home = lazyPage(() => import("../pages/Home"), "Home");
+const Configuracion = lazyPage(() => import("../pages/Configuracion"), "Configuracion");
+const Categorias = lazyPage(() => import("../pages/Categorias"), "Categorias");
+const Movimientos = lazyPage(() => import("../pages/Movimientos"), "Movimientos");
+const ImportarMovimientos = lazyPage(() => import("../pages/ImportarMovimientos"), "ImportarMovimientos");
+const Informes = lazyPage(() => import("../pages/Informes"), "Informes");
+const Vincular = lazyPage(() => import("../pages/Vincular"), "Vincular");
+const Conexiones = lazyPage(() => import("../pages/Conexiones"), "Conexiones");
+const Dashboard = lazyPage(() => import("../pages/Dashboard"), "Dashboard");
+const Cuentas = lazyPage(() => import("../pages/Cuentas"), "Cuentas");
+
+const protectedRoutes = [
+  { path: "/", element: <Home /> },
+  { path: "/home", element: <Home /> },
+  { path: "/dashboard", element: <Dashboard /> },
+  { path: "/cuentas", element: <Cuentas /> },
+  { path: "/conexiones", element: <Conexiones /> },
+  { path: "/vincular", element: <Vincular /> },
+  { path: "/configurar", element: <Configuracion /> },
+  { path: "/categorias", element: <Categorias /> },
+  { path: "/movimientos", element: <Movimientos /> },
+  { path: "/movimientos/importar", element: <ImportarMovimientos /> },
+  { path: "/informes", element: <Informes /> },
+  { path: "/acercade", element: <Home /> },
+];
 
 interface ProtectedRouteProps {
   isLoading: boolean;
@@ -42,18 +50,9 @@ export const MyRoutes = ({ isLoading }: ProtectedRouteProps) => {
         <Route path="/login" element={<Login />} />
         <Route path="/auth/callback" element={<AuthCallback />} />
         <Route element={<ProtectedRoute user={user} redirectTo="/" isLoading={isLoading} />}>
-          <Route path="/" element={<Home />} />
-          <Route path="/home" element={<Home />} />
-          <Route path="/dashboard" element={<Dashboard />} />
-          <Route path="/cuentas" element={<Cuentas />} />
-          <Route path="/conexiones" element={<Conexiones />} />
-          <Route path="/vincular" element={<Vincular />} />
-          <Route path="/configurar" element={<Configuracion />} />
-          <Route path="/categorias" element={<Categorias />} />
-          <Route path="/movimientos" element={<Movimientos />} />
-          <Route path="/movimientos/importar" element={<ImportarMovimientos />} />
-          <Route path="/informes" element={<Informes />} />
-          <Route path="/acercade" element={<Home />} />
+          {protectedRoutes.map((route) => (
+            <Route key={route.path} path={route.path} element={route.element} />
+          ))}
         </Route>
       </Routes>
     </Suspense>


### PR DESCRIPTION
### Motivation
- Mejorar la experiencia de usuario en la pantalla de `Informes` mostrando información útil y evitando exportaciones vacías.
- Reutilizar el dataset filtrado para cálculos y exportaciones para evitar inconsistencias y llamadas redundantes.
- Reducir repetición en la configuración de rutas lazy y facilitar el mantenimiento con un helper tipado.

### Description
- En `src/components/templates/InformesTemplate.tsx` se agrega memoización del dataset (`reportData`) y un resumen calculado (`reportSummary`) con totales de ingresos, gastos, transferencias y cantidad de registros.  
- Se reutiliza `reportData` para las exportaciones `JSON`, `Excel` y `PDF` y se deshabilitan los botones de exportación cuando no hay filas exportables (`exportDisabled`).  
- Se añade un estado vacío (`EmptyState`) y un grid de tarjetas (`SummaryGrid` / `SummaryCard`) que mejora la lectura rápida del informe y guía al usuario cuando no hay datos.  
- En `src/routers/routes.tsx` se introduce `lazyPage`, un helper genérico tipado para crear rutas lazy y un array `protectedRoutes` que centraliza las rutas protegidas, sustituyendo listas repetitivas de `Route` por un mapeo.

### Testing
- Ejecutado `npm test` y todos los tests unitarios pasaron: `4 files, 30 tests` (✅).  
- Ejecutado `npm run build` y la aplicación se construyó correctamente con `vite build` (✅).  
- Ejecutado `npx tsc -b --pretty false` y falló por errores de tipado preexistentes en archivos no modificados (por ejemplo `src/components/ErrorBoundary.tsx`, `src/components/atomos/Colorcontent.tsx`, `src/supabase/crudMovimientos.tsx` y problemas en `tsconfig.node.json`) (❌).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa81555f108320bf1a633956c305fa)